### PR TITLE
Added ARDUINOONPC define for arduino code, allow custom TFT size.

### DIFF
--- a/makeNativeArduino.mk
+++ b/makeNativeArduino.mk
@@ -16,12 +16,14 @@ CFLAGS += -Wall -Wextra -Wno-unused-parameter
 CFLAGS += -DARDUINO=101 -DSKETCH_FILE=\"$(SKETCH)\"
 CFLAGS += -std=gnu11
 CFLAGS += -lm
+CFLAGS += -DARDUINOONPC
 #CFLAGS += -DFASTLED_SDL $(shell sdl2-config --cflags)
 
 CXXFLAGS += -Wall -Wextra -Wno-unused-parameter
 CXXFLAGS += -DARDUINO=101 -DSKETCH_FILE=\"$(SKETCH)\"
 CXXFLAGS += -Wno-class-memaccess # FastLED does some naughty things
 CXXFLAGS += -std=gnu++11
+CXXFLAGS += -DARDUINOONPC
 #CXXFLAGS += -DFASTLED_SDL $(shell sdl2-config --cflags)
 
 LDFLAGS += -Wl,--gc-sections
@@ -81,8 +83,6 @@ print:
 	@echo "SRC_CXX :\t $(SRC_CXX)"
 	@echo "SRC_USER:\t $(SRC_USER)"
 	@echo ":\t $(INC_USER_FOLDERS)"
-
-
 
 
 $(BUILD_ROOT)/%.o : %.c $(DEPDIR)/%.d

--- a/src/system/TFT_LinuxWrapper.h
+++ b/src/system/TFT_LinuxWrapper.h
@@ -37,7 +37,7 @@
 // attention: size optitions to be reworked!
 
 #define TFT_WIDTH 480
-#define TFT_HEIGTH 272
+#define TFT_HEIGHT 272
 
 class TFT_LinuxWrapper : public Adafruit_GFX
 {
@@ -45,11 +45,18 @@ class TFT_LinuxWrapper : public Adafruit_GFX
 
   public:
 
-	XWindow *win;
+    XWindow *win;
 
-    TFT_LinuxWrapper(): Adafruit_GFX((int16_t) TFT_HEIGTH, (int16_t) TFT_WIDTH)
+    // FIXME: add comment, why are X and Y reversed and setRotation(1) used below?
+    TFT_LinuxWrapper(): Adafruit_GFX((int16_t) TFT_HEIGHT, (int16_t) TFT_WIDTH)
     {
-    	win=new XWindow(TFT_WIDTH,TFT_HEIGTH,"TFT emulation");
+    	win=new XWindow(TFT_WIDTH,TFT_HEIGHT,"TFT emulation");
+    }
+
+    // FIXME: reversed too, see above.
+    TFT_LinuxWrapper(uint16_t sizex, uint16_t sizey): Adafruit_GFX(sizey, sizex)
+    {
+    	win=new XWindow(sizex, sizey,"TFT emulation");
     }
 
     void init()


### PR DESCRIPTION
Allow arduino code to know that it's running on this pseudo hardware
backend, by defining ARDUINOONPC.
Also allow setting a custom tft size in TFT_LinuxWrapper
TFT_HEIGTH -> TFT_HEIGHT